### PR TITLE
Deprecate default constructors

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+dgm-lib v2.4.0
+ * Deprecated default constructors for Clip, Window, Path and TileMap
+ * Added examples target
+    * Build by default, you can use `-D ENABLE_EXAMPLES=OFF` to surpress on configure
+    * Examples showcase various features of the library and how to use them
+
 dgm-lib v2.3.1
  * Fixed `WorldNavMesh` internal lookup algorithm, which could produce paths that go through solid walls
  * Fixed `WorldNavMesh` internal lookup algorithm, which could not find path in an empty room

--- a/examples/example-04-particle-effects/Main.cpp
+++ b/examples/example-04-particle-effects/Main.cpp
@@ -35,7 +35,7 @@ sf::RectangleShape createVisualContainer(unsigned x, unsigned y)
 
 int main()
 {
-    srand(time(nullptr));
+    srand(static_cast<unsigned>(time(nullptr)));
 
     auto&& window =
         dgm::Window(WINDOW_SIZE_U, "Example: Particle Effects", false);

--- a/examples/example-05-camera-manual-control/Main.cpp
+++ b/examples/example-05-camera-manual-control/Main.cpp
@@ -51,7 +51,7 @@ int main(int, char*[])
         sf::Event event;
         while (window.pollEvent(event))
         {
-            if (event.type == sf::Event::Closed())
+            if (event.type == sf::Event::Closed)
                 std::ignore = window.close();
             else if (event.type == sf::Event::KeyPressed)
             {

--- a/lib/include/DGM/classes/Clip.hpp
+++ b/lib/include/DGM/classes/Clip.hpp
@@ -70,7 +70,7 @@ namespace dgm
             const std::size_t frameCount = 0,
             const sf::Vector2u& frameSpacing = sf::Vector2u(0, 0));
 
-        [[nodiscard]] Clip() = default;
+        [[nodiscard, deprecated]] Clip() = default;
 
         [[nodiscard]] Clip(
             const sf::Vector2u& frameSize,

--- a/lib/include/DGM/classes/Path.hpp
+++ b/lib/include/DGM/classes/Path.hpp
@@ -56,7 +56,7 @@ namespace dgm
     class [[nodiscard]] Path final
     {
     public:
-        Path() = default;
+        [[deprecated]] Path() = default;
 
         Path(const std::vector<T>& points, bool looping)
             : points(points), looping(looping)

--- a/lib/include/DGM/classes/TileMap.hpp
+++ b/lib/include/DGM/classes/TileMap.hpp
@@ -99,7 +99,7 @@ namespace dgm
             return clip;
         }
 
-        [[nodiscard]] TileMap() = default;
+        [[nodiscard, deprecated]] TileMap() = default;
 
         template<UniversalReference<dgm::Clip> _Clip>
         [[nodiscard]] explicit TileMap(const sf::Texture& texture, _Clip&& clip)

--- a/lib/include/DGM/classes/Window.hpp
+++ b/lib/include/DGM/classes/Window.hpp
@@ -185,7 +185,7 @@ namespace dgm
         }
 
         Window(Window&&) = delete;
-        Window(Window&) = delete;
+        Window(const Window&) = delete;
 
         virtual ~Window()
         {


### PR DESCRIPTION
* Deprecated default constructors for Clip, Window, Path and TileMap
* Fixed some warnings in examples