### PR TITLE
dgm::Controller::readAnalog only returns positive values

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+dgm-lib v3.1.0
+ * `dgm::Controller::readAnalog` no longer returns negative values for negative axii halves
+    * One gamepad could've a negative half on up, second could have it on down, it is easier to handle in client code this way
+
 dgm-lib v3.0.0
  * Library target has been renamed to `dgm-lib` and a `dgm::dgm-lib` alias has been added. Use that for linking
  * You can now use `find_package` on a downloaded release to easily link the library. See docs/integration for details

--- a/examples/example-02-controller/Main.cpp
+++ b/examples/example-02-controller/Main.cpp
@@ -492,8 +492,8 @@ int main()
             Action up, Action down, Action left, Action right) -> sf::Vector2f
     {
         return sf::Vector2f(
-                   input.readAnalog(left) + input.readAnalog(right),
-                   input.readAnalog(up) + input.readAnalog(down))
+                   -input.readAnalog(left) + input.readAnalog(right),
+                   -input.readAnalog(up) + input.readAnalog(down))
                * 100.f;
     };
 

--- a/lib/include/DGM/classes/Controller.hpp
+++ b/lib/include/DGM/classes/Controller.hpp
@@ -80,8 +80,7 @@ namespace dgm
             auto& binding = bindings.at(code);
             if (isMouseInputToggled(binding) || isKeyboardInputToggled(binding)
                 || isGamepadInputToggled(binding))
-                return bindings[code].axisHalf == AxisHalf::Positive ? 1.f
-                                                                     : -1.f;
+                return 1.f;
 
             if (!sf::Joystick::isConnected(controllerIndex)) return 0.f;
 
@@ -207,13 +206,15 @@ namespace dgm
         {
             if (std::to_underlying(binding.axis) == sf::Joystick::AxisCount)
                 return 0.f;
-            const float value =
+
+            const float rawValue =
                 sf::Joystick::getAxisPosition(controllerIndex, binding.axis)
                 / 100.f;
-            return std::clamp(
-                std::abs(value) < controllerDeadzone ? 0.f : value,
+            const float axisHalfValue = std::abs(std::clamp(
+                rawValue,
                 binding.axisHalf == dgm::AxisHalf::Negative ? -1.f : 0.f,
-                binding.axisHalf == dgm::AxisHalf::Positive ? 1.f : 0.f);
+                binding.axisHalf == dgm::AxisHalf::Positive ? 1.f : 0.f));
+            return axisHalfValue < controllerDeadzone ? 0.f : axisHalfValue;
         }
 
     private:


### PR DESCRIPTION
`dgm::Controller::readAnalog` no longer returns negative values for negative axii halves
    * One gamepad could've a negative half on up, second could have it on down, it is easier to handle in client code this way